### PR TITLE
add pixiv/phixiv to supported replacements

### DIFF
--- a/bot_tools.py
+++ b/bot_tools.py
@@ -3,7 +3,8 @@ import re
 social_key = {
     'twt': 'vxtwitter',
     'ig': 'www.ddinstagram',
-    'tt': 'www.vxtiktok'
+    'tt': 'www.vxtiktok',
+    'px': 'www.phixiv'
 }
 
 def find_url_index(url, str):
@@ -16,7 +17,11 @@ def get_urls(msg, ind):
     return urls
 
 def change_to_vx(domain, urls, social):
+    if social == 'px': tld = 'net'
+    else: tld = 'com'
+        
     social = social_key[social]
+
     for i, url in enumerate(urls):
-        urls[i] = url.replace(domain, f'https://{social}.com')
+        urls[i] = url.replace(domain, f'https://{social}.{tld}')
     return urls

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ async def help(ctx): # how to use bot
                     "2. instagram.com\n" + \
                     "3. x.com\n" + \
                     "4. twitter.com\n" + \
+                    "5. pixiv.com\n" + \
                     "They can be embedded among text in the message or be its own message." + \
                     "\n**If you need to delete a message from the bot, type !delete to get rid of the last message "+ \
                     "from the bot. Right now the bot doesn't recognize a hidden link using <> as one that you "+ \
@@ -65,6 +66,12 @@ async def on_message(message):
         urls = tools.change_to_vx('https://www.instagram.com', urls, 'ig')
         await message.channel.send('\n'.join(urls))
 
+    if 'https://www.pixiv.net' in message.content:
+        await message.edit(suppress=True)
+        ind = tools.find_url_index('https://www.pixiv.net', message.content)
+        urls = tools.get_urls(message.content, ind)
+        urls = tools.change_to_vx('https://www.pixiv.net', urls, 'px')
+        await message.channel.send('\n'.join(urls))
     await bot.process_commands(message)
 
 # try:


### PR DESCRIPTION
pixiv urls can now be replaced with phixiv. additionally, pixiv is added to the help menu as a supported site for embeds